### PR TITLE
Remove "conflicts" with stable Rider version

### DIFF
--- a/Casks/rider-eap.rb
+++ b/Casks/rider-eap.rb
@@ -20,7 +20,6 @@ cask "rider-eap" do
   end
 
   auto_updates true
-  conflicts_with cask: "homebrew/cask/rider"
   depends_on macos: ">= :high_sierra"
 
   app "Rider EAP.app"


### PR DESCRIPTION
Remove "conflicts" with stable Rider version to allow side by side installation.

Verified by installing versions 2023.1 and 2023.2 EAP 2 side by side.