### PR TITLE
Tweak GHA configs a bit

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: macauley/action-homebrew-bump-cask@v1
       with:
         token: ${{ secrets.GH_TOKEN }}
-        tap: ${{ github.repository_owner }}/jetbrains-eap
+        tap: ${{ github.repository }}
         cask: >-
           clion-eap,
           datagrip-eap,

--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   bump:
     runs-on: macos-latest
+    if: github.repository == 'dahlia/homebrew-jetbrains-eap'
     steps:
     - uses: macauley/action-homebrew-bump-cask@v1
       with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,5 +9,5 @@ jobs:
   check:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: hooks/pre-commit


### PR DESCRIPTION
- Bump `actions/checkout` to v4, the v2 versions are deprecated.
  > Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
- Run auto bump job in upstream repo only, cause there are no required tokens in forked repos by default, which will fail this job.