### PR TITLE
Track EAP's .app change, and rename to avoid conflict

### DIFF
--- a/Casks/intellij-idea-ce-eap.rb
+++ b/Casks/intellij-idea-ce-eap.rb
@@ -23,8 +23,8 @@ cask "intellij-idea-ce-eap" do
   auto_updates true
   depends_on macos: ">= :high_sierra"
 
-  app "IntelliJ IDEA #{version.major_minor} CE EAP.app"
-  binary "#{appdir}/IntelliJ IDEA #{version.major_minor} CE EAP.app/Contents/MacOS/idea", target: "idea-ce-eap"
+  app "IntelliJ IDEA CE.app", target: "IntelliJ IDEA CE EAP.app"
+  binary "#{appdir}/IntelliJ IDEA CE.app/Contents/MacOS/idea", target: "idea-ce-eap"
 
   uninstall_postflight do
     ENV["PATH"].split(File::PATH_SEPARATOR).map { |path| File.join(path, "idea") }.each do |path|


### PR DESCRIPTION
This closes #592, but it might be occurring in other EAPs as well.